### PR TITLE
fix: allow multiple pipes to split

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -221,7 +221,7 @@ class ConventionalCommitMessage {
   public async getBody(): Promise<void> {
     if (this.next) {
       this.next = await ask('Provide a LONGER description of the change (optional). Use "|" to break new line',
-        input => this.body = wrap(input.replace('|', '\n'), 72, {hard: true}));
+        input => this.body = wrap(input.split('|').join('\n'), 72, {hard: true}));
     }
   }
 


### PR DESCRIPTION
code was only splitting the first pipe found in the long description

A quick demonstration of the code changes:
http://jsbin.com/kumonimiqe/edit?js,console

Closes #29