### PR TITLE
feat(commit): Auto-stage with enableSmartCommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
   "dependencies": {
     "execa": "^1.0.0",
     "sander": "^0.6.0",
-    "simple-git": "1.104.0",
     "wrap-ansi": "^3.0.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   "dependencies": {
     "execa": "^1.0.0",
     "sander": "^0.6.0",
+    "simple-git": "1.104.0",
     "wrap-ansi": "^3.0.1"
   },
   "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -214,17 +214,17 @@ async function conditionallyStageFiles(cwd: string): Promise<void> {
   const hasSmartCommitEnabled = vscode.workspace.getConfiguration('git')
     .get<boolean>('enableSmartCommit') === true;
 
-  if (hasSmartCommitEnabled && await hasNoStagedFiles(cwd)) {
+  if (hasSmartCommitEnabled && !(await hasStagedFiles(cwd))) {
     channel.appendLine('Staging all files (enableSmartCommit enabled with nothing staged)');
     await execa('git', ['add', '-A', '--', '.'], {cwd});
   }
 }
 
-async function hasNoStagedFiles(cwd: string): Promise<boolean> {
+async function hasStagedFiles(cwd: string): Promise<boolean> {
   const git = simplegit();
   await git.cwd(cwd);
   const status = await git.status();
-  return status.files.every((file: {index: string}) => !file.index.trim() || file.index === '?');
+  return status.files.some((file: {index: string}) => !!file.index.trim() && file.index !== '?');
 }
 
 class ConventionalCommitMessage {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 import * as execa from 'execa';
 import { join } from 'path';
 import * as sander from 'sander';
-import * as simplegit from 'simple-git/promise';
 // tslint:disable-next-line:no-implicit-dependencies
 import * as vscode from 'vscode';
 import * as wrap from 'wrap-ansi';
@@ -221,10 +220,8 @@ async function conditionallyStageFiles(cwd: string): Promise<void> {
 }
 
 async function hasStagedFiles(cwd: string): Promise<boolean> {
-  const git = simplegit();
-  await git.cwd(cwd);
-  const status = await git.status();
-  return status.files.some((file: {index: string}) => !!file.index.trim() && file.index !== '?');
+  const result = await execa('git', ['diff', '--name-only', '--cached'], {cwd});
+  return hasOutput(result);
 }
 
 class ConventionalCommitMessage {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -216,7 +216,7 @@ async function conditionallyStageFiles(cwd: string): Promise<void> {
 
   if (hasSmartCommitEnabled && !(await hasStagedFiles(cwd))) {
     channel.appendLine('Staging all files (enableSmartCommit enabled with nothing staged)');
-    await execa('git', ['add', '-A', '--', '.'], {cwd});
+    await vscode.commands.executeCommand('git.stageAll');
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,6 +822,13 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.0.1.tgz#f9bb36d439b8d1f0dd52d8fb6b46e4ebb8c1cd5b"
+  integrity sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize-keys@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -2190,6 +2197,11 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
 multimatch@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
@@ -2913,6 +2925,13 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+simple-git@1.104.0:
+  version "1.104.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.104.0.tgz#c2081564d0045c9d121d321a0df0c5eea9a421b1"
+  integrity sha512-KTELLFyhLhN1qZGQkglx1e0YezYKNabCY4oKrTVb9y0BllkWwruK2qFCQDm2zpT7rE4IPd4/hzZt/6+0ykQIdA==
+  dependencies:
+    debug "^4.0.1"
 
 slash@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,13 +822,6 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.0.1.tgz#f9bb36d439b8d1f0dd52d8fb6b46e4ebb8c1cd5b"
-  integrity sha512-K23FHJ/Mt404FSlp6gSZCevIbTMLX0j3fmHhUEhQ3Wq0FMODW3+cUSoLdy1Gx4polAf4t/lphhmHH35BB8cLYw==
-  dependencies:
-    ms "^2.1.1"
-
 decamelize-keys@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -2197,11 +2190,6 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
-  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
-
 multimatch@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
@@ -2925,13 +2913,6 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
-
-simple-git@1.104.0:
-  version "1.104.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.104.0.tgz#c2081564d0045c9d121d321a0df0c5eea9a421b1"
-  integrity sha512-KTELLFyhLhN1qZGQkglx1e0YezYKNabCY4oKrTVb9y0BllkWwruK2qFCQDm2zpT7rE4IPd4/hzZt/6+0ykQIdA==
-  dependencies:
-    debug "^4.0.1"
 
 slash@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR closes #80.

Before committing, we now check if the user has `enableSmartCommit` enabled. If so, we execute an additional command that stages all files before proceeding with the commit.

~~I couldn't find a [vscode command](https://github.com/Microsoft/vscode/blob/master/extensions/git/src/commands.ts) that checked for unstaged files, so I brought in [`simple-git`](https://www.npmjs.com/package/simple-git) as a dependency.~~