### PR TITLE
feat: add option to toggle quoting the git message

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
           ],
           "default": "onError",
           "description": "Open the output panel after commit."
+        },
+        "commitizen.quoteMessageInGitCommit": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to true to put double quotes around the message when calling git -m."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "commands": [
       {
         "command": "vscode-commitizen.commit",
-        "title": "conventional commit",
+        "title": "Conventional Commit",
         "category": "Commitizen"
       }
     ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ interface Configuration {
   autoSync: boolean;
   subjectLength: number;
   showOutputChannel: 'off' | 'always' | 'onError';
+  quoteMessageInGitCommit: boolean;
 }
 
 function getConfiguration(): Configuration {
@@ -194,9 +195,16 @@ const DEFAULT_MESSAGES = {
 
 async function commit(cwd: string, message: string): Promise<void> {
   channel.appendLine(`About to commit '${message}'`);
+
+  let messageForGit = message;
+
+  if (getConfiguration().quoteMessageInGitCommit) {
+    messageForGit = `"${message}"`;
+  }
+
   try {
     await conditionallyStageFiles(cwd);
-    const result = await execa('git', ['commit', '-m', `"${message}"`], {cwd});
+    const result = await execa('git', ['commit', '-m', messageForGit], {cwd});
     await vscode.commands.executeCommand('git.refresh');
     if (getConfiguration().autoSync) {
       await vscode.commands.executeCommand('git.sync');


### PR DESCRIPTION
## Summary

The fix for issue #215 adds double quotes to the git message prior to calling git commit -m. However, there are situations where the message ends up like this:
    
```
        "docs: Update README.md"
```

instead of:

```    
        docs: Update README.md
``` 
    
There's also situations where if you don't double quote the message, `execa()` does this and causes an error:
    
```
        git commit -m docs: Update README.md
``` 
    
Instead of this:

```    
        git commit -m "docs: Update README.md"
``` 

I don't know if it's because of a dependency, old version, or something else. 

So, it may be easier to let users determine whether to quote the message or not in case things like this happen again.

This is also related to issue #213.

## Screenshots

Screenshot of the extension sometimes including double quotes in the git commit message. Also shows the option to toggle them.
![optional-quotes-commitizen](https://user-images.githubusercontent.com/50994416/86746169-0f59e180-c065-11ea-894e-0f9b1efd768e.png)

Screenshot of the the extension sending a command to git without quotes.
![erronous-commitizen](https://user-images.githubusercontent.com/50994416/86746804-84c5b200-c065-11ea-93cd-92c4df0c9550.png)
