### PR TITLE
fix: includeif with lowercase drive letter (#296)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
           "type": "boolean",
           "default": true,
           "description": "Set to true to put double quotes around the message when calling git -m."
+        },
+        "commitizen.capitalizeWindowsDriveLetter": {
+          "type": "boolean",
+          "default": false,
+          "description": "Set to true to capitalize the Windows drive letter in Git's working directory path. Git treats paths as case sensitive and may ignore [includeIf] attributes in your .gitconfig if drive letters are the wrong case."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -390,7 +390,9 @@ class ConventionalCommitMessage {
 }
 
 function capitalizeWindowsDriveLetter(path: string): string {
-  if (!path) return path;
+  if (!path) {
+    return path;
+  }
 
   return path.replace(/(\w+?):/, rootElement => {
     return rootElement.toUpperCase();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,7 +202,6 @@ async function commit(cwd: string, message: string): Promise<void> {
   if (getConfiguration().quoteMessageInGitCommit) {
     messageForGit = `"${message}"`;
   }
-  
   let cwdForGit = cwd;
 
   if (getConfiguration().capitalizeWindowsDriveLetter) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -402,8 +402,8 @@ function getGitCmdArgs(message: string, cwd: string): GitCmdArgs {
   }
 
   return {
-    message,
-    cwd
+    message: messageForGit,
+    cwd: cwdForGit
   };
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -197,20 +197,11 @@ const DEFAULT_MESSAGES = {
 async function commit(cwd: string, message: string): Promise<void> {
   channel.appendLine(`About to commit '${message}'`);
 
-  let messageForGit = message;
-
-  if (getConfiguration().quoteMessageInGitCommit) {
-    messageForGit = `"${message}"`;
-  }
-  let cwdForGit = cwd;
-
-  if (getConfiguration().capitalizeWindowsDriveLetter) {
-    cwdForGit = capitalizeWindowsDriveLetter(cwd);
-  }
+  const gitCmdArgs = getGitCmdArgs(message, cwd);
 
   try {
     await conditionallyStageFiles(cwd);
-    const result = await execa('git', ['commit', '-m', messageForGit], {cwd: cwdForGit});
+    const result = await execa('git', ['commit', '-m', gitCmdArgs.message], { cwd: gitCmdArgs.cwd });
     await vscode.commands.executeCommand('git.refresh');
     if (getConfiguration().autoSync) {
       await vscode.commands.executeCommand('git.sync');
@@ -396,4 +387,27 @@ function capitalizeWindowsDriveLetter(path: string): string {
   return path.replace(/(\w+?):/, rootElement => {
     return rootElement.toUpperCase();
   });
+}
+
+function getGitCmdArgs(message: string, cwd: string): GitCmdArgs {
+  let messageForGit = message;
+
+  if (getConfiguration().quoteMessageInGitCommit) {
+    messageForGit = `"${message}"`;
+  }
+  let cwdForGit = cwd;
+
+  if (getConfiguration().capitalizeWindowsDriveLetter) {
+    cwdForGit = capitalizeWindowsDriveLetter(cwd);
+  }
+
+  return {
+    message,
+    cwd
+  };
+}
+
+interface GitCmdArgs {
+  message: string;
+  cwd: string;
 }


### PR DESCRIPTION
Add the option to capitalize Windows drive letters prior to passing it
to exac().

The problem is Git treats path as case sensitive so if you set something
like

    [includeIf "gitdir:D:/foo/bar/"]
        path = ~/.gitconfig-1

The extension will throw an error since Git's working directory is
d:/foo/bar.