### PR TITLE
fix: Cannot read property 'czConfig' of undefined

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -323,23 +323,6 @@ class ConventionalCommitMessage {
     );
   }
 
-  private static getScopePicks(
-    czConfig: CzConfig,
-    inputMessage: (inputMessage: string) => string
-  ): { label: string; description: string }[] {
-    const scopePicks = czConfig.scopes.map((scope) => ({
-      label: scope.name || (scope as string),
-      description: ''
-    }));
-    if (czConfig.allowCustomScopes) {
-      scopePicks.push({
-        label: inputMessage('customScopeEntry'),
-        description: ''
-      });
-    }
-    return scopePicks;
-  }
-
   private readonly czConfig: CzConfig | undefined;
   private next = true;
 
@@ -372,11 +355,17 @@ class ConventionalCommitMessage {
   public async getScope(): Promise<void> {
     if (this.next) {
       if (ConventionalCommitMessage.hasScopes(this.czConfig)) {
-        if (this.czConfig.scopes && this.czConfig.scopes[0] !== undefined) {
-          const scopePicks = ConventionalCommitMessage.getScopePicks(
-            this.czConfig,
-            this.inputMessage
-          );
+        if (this.czConfig.scopes && this.czConfig.scopes[0] !== undefined) {          
+          const scopePicks = this.czConfig.scopes.map((scope) => ({
+            label: scope.name || (scope as string),
+            description: ''
+          }));
+          if (this.czConfig.allowCustomScopes) {
+            scopePicks.push({
+              label: this.inputMessage('customScopeEntry'),
+              description: ''
+            });
+          }
           this.next = await askOneOf(
             this.inputMessage('customScope'),
             scopePicks,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -384,7 +384,7 @@ class ConventionalCommitMessage {
               this.scope = pick.label || undefined;
             },
             this.inputMessage('customScopeEntry'),
-            this.inputMessage('customScope')
+            this.inputMessage('customScope').bind(this)
           );
         }
       } else if (


### PR DESCRIPTION
I think i've found the issue (hopefully) but somehow the config brakes once you add allowCustomScopes prop to .cz-config.js.

If you comment this prop from default config (https://github.com/leonardoanalista/cz-customizable/blob/master/cz-config-EXAMPLE.js) it works, at least on my end. I hope this helps!

error:

```ts
const scopePicks = ConventionalCommitMessage.getScopePicks(
     this.czConfig,
     this.inputMessage
);
```

`this.inputMessage()` bind `this`  is not `ConventionalCommitMessage`。

fix:


```ts
const scopePicks = ConventionalCommitMessage.getScopePicks(
     this.czConfig,
     this.inputMessage.bind(this)
);
```

> v0.8.3 is not `ConventionalCommitMessage.getScopePicks()` 

ok，Good job！
