### PR TITLE
fix: bug allowBreakingChanges

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -350,7 +350,7 @@ class ConventionalCommitMessage {
       );
     }
 
-    return false;
+    return true;
   }
 
   private readonly czConfig: CzConfig | undefined;


### PR DESCRIPTION
Fixed a bug. If the parameter is not specified in the allowBreakingChanges configuration, then it was skipped for all types, and it should be the other way around