### PR TITLE
feat: add shell option

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
           "type": "boolean",
           "default": false,
           "description": "Set to true to capitalize the Windows drive letter in Git's working directory path. Git treats paths as case sensitive and may ignore [includeIf] attributes in your .gitconfig if drive letters are the wrong case."
+        },
+        "commitizen.shell": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set to true to runs file inside of a shell. Uses /bin/sh on UNIX and cmd.exe on Windows."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ interface Configuration {
   showOutputChannel: 'off' | 'always' | 'onError';
   quoteMessageInGitCommit: boolean;
   capitalizeWindowsDriveLetter: boolean;
+  shell: boolean;
 }
 
 function getConfiguration(): Configuration {
@@ -243,7 +244,7 @@ async function commit(cwd: string, message: string): Promise<void> {
     const result = await execa('git', ['commit', '-m', gitCmdArgs.message], {
       cwd: gitCmdArgs.cwd,
       preferLocal: false,
-      shell: true
+      shell: getConfiguration().shell
     });
     await vscode.commands.executeCommand('git.refresh');
     if (getConfiguration().autoSync) {


### PR DESCRIPTION
On windows, Only the first line makes it to the final commit message. this option and the exist `quoteMessageInGitCommit` option set to be false will fix this issue.

Close #325