### PR TITLE
fix: gitroot only worked once

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,7 +111,7 @@ async function findLookupPath(): Promise<string | undefined> {
   }
 
   if (getConfiguration().useGitRoot) {
-    if (gitRoot === undefined)
+    if (gitRoot === undefined) {
       gitRoot = await new Promise<string>((resolve, reject) =>
         exec(
           'git rev-parse --show-toplevel',
@@ -134,6 +134,7 @@ async function findLookupPath(): Promise<string | undefined> {
         }
         return undefined;
       });
+    }
 
     return gitRoot;
   }


### PR DESCRIPTION
Git Root was only working once on load since the return statement was moved up.
Fix was to shift the gitroot null check into its own if statement.