### PR TITLE
feat(icon): add an icon beside the git scm

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,10 +70,20 @@
     "commands": [
       {
         "command": "vscode-commitizen.commit",
-        "title": "Conventional Commit",
-        "category": "Commitizen"
+        "title": "Conventional Commits",
+        "category": "Commitizen",
+        "icon": "images/commitizen-logo.png"
       }
-    ]
+    ],
+    "menus": {
+      "scm/title": [
+        {
+          "when": "scmProvider == git",
+          "command": "vscode-commitizen.commit",
+          "group": "navigation"
+        }
+      ]
+    }
   },
   "scripts": {
     "linter": "tslint --project .",


### PR DESCRIPTION
This PR adds the Commitizen Logo present in the images directory beside the Refresh Icon in Git SCM. The end result looks like this
![Screenshot from 2021-07-05 17-31-57](https://user-images.githubusercontent.com/67627239/124470235-ffc8c200-ddb8-11eb-9859-84d75d74c312.png)
