### PR TITLE
feat: add option to sign and verify commits 

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
           "type": "boolean",
           "default": true,
           "description": "Set to true to runs file inside of a shell. Uses /bin/sh on UNIX and cmd.exe on Windows."
+        },
+        "commitizen.signCommits": {
+          "type": "boolean",
+          "default": false,
+          "description": "Set to true to sign commits by adding the -S flag"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ interface Configuration {
   capitalizeWindowsDriveLetter: boolean;
   useGitRoot: boolean;
   shell: boolean;
+  signCommits: boolean;
 }
 
 function getConfiguration(): Configuration {
@@ -295,7 +296,8 @@ async function commit(cwd: string, message: string): Promise<void> {
 
   try {
     await conditionallyStageFiles(cwd);
-    const result = await execa('git', ['commit', '-m', gitCmdArgs.message], {
+    const signArgument = getConfiguration().signCommits ? ['-S'] : [];
+    const result = await execa('git', ['commit', '-m', gitCmdArgs.message, ...signArgument], {
       cwd: gitCmdArgs.cwd,
       preferLocal: false,
       shell: getConfiguration().shell


### PR DESCRIPTION
I am not so sure, because I have not tested it. But what it should do is adding a setting `signCommits` and if it is set to true, add the `-S` flag to the git commit command.  #546

Please try before merging it.

Signed-off-by: euberdeveloper <euberdeveloper@gmail.com>