### PR TITLE
fix(commit): fix missing body and footer message

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,6 @@
           "default": "onError",
           "description": "Open the output panel after commit."
         },
-        "commitizen.quoteMessageInGitCommit": {
-          "type": "boolean",
-          "default": true,
-          "description": "Set to true to put double quotes around the message when calling git -m."
-        },
         "commitizen.capitalizeWindowsDriveLetter": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
# Problem

The body and footer message missing in the commit message.

# Reason

Use ` '\n' ` to add a new line doesn't work in the command line.

```
execa('git', ['commit', '-m', '"FirstRow\nSecondRow"']);
```

# Reference

https://stackoverflow.com/questions/5064563/add-line-break-to-git-commit-m-from-the-command-line/

# Solution

Use the `-m` parameter to separate multiple lines.

```
execa('git', ['commit', '-m', '"FirstRow"', '-m', '"SecondRow"']);
```

# Breaking Change

`quoteMessageInGitCommit` option has been removed, because of unnecessary. New design must use quotation marks.

# Snapshot

![commit-snapshot](https://user-images.githubusercontent.com/24559988/131256837-92ac962b-f87c-441a-b32b-5160b5ec0244.jpg)

Closes #443, #527