### PR TITLE
:bug:(format) prevent body to equal the string "undefined" when skipped

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,7 +77,7 @@ interface CzConfig {
 }
 type Messages = {
   main: string;
-  body: string;
+  body?: string;
   footer: string;
 };
 
@@ -564,7 +564,7 @@ class ConventionalCommitMessage {
     const main = `${this.type}${typeof this.scope === 'string' && this.scope ?
       `(${this.scope})` : ''
       }: ${this.subject}`;
-    const body = `${this.body}`;
+    const body = this.body;
     const footer = `${this.breaking ? `BREAKING CHANGE: ${this.breaking}|` : ''}${this.messageFooter()}`;
 
     return {


### PR DESCRIPTION
When the body question is skipped in the config, the variable this.body is undefined and when casted into string its value become 'undefined'.
This make the commit to have an extra line break the word "undefined" in it.

This commit aims to prevent this behaviour
